### PR TITLE
refactor: moved some TypeScript interfaces

### DIFF
--- a/components/SearchProjects.tsx
+++ b/components/SearchProjects.tsx
@@ -1,7 +1,7 @@
 import { gql, useQuery } from "@apollo/client";
 import { Autocomplete, Icon } from "@bbtgnn/polaris-interfacer";
 import { SearchMinor } from "@shopify/polaris-icons";
-import { ProjectType } from "components/types";
+import { ProjectType, SelectOption } from "components/types";
 import { QUERY_PROJECT_TYPES } from "lib/QueryAndMutation";
 import { EconomicResource, GetProjectTypesQuery, SearchProjectsQuery, SearchProjectsQueryVariables } from "lib/types";
 import { useTranslation } from "next-i18next";
@@ -127,12 +127,6 @@ export default function SearchProjects(props: Props) {
 }
 
 //
-
-export interface SelectOption {
-  value: string;
-  label: string;
-  media?: React.ReactElement;
-}
 
 export const SEARCH_PROJECTS = gql`
   query SearchProjects($last: Int, $IDs: [ID!], $name: String, $conformsTo: [ID!]) {

--- a/components/SearchProjects.tsx
+++ b/components/SearchProjects.tsx
@@ -1,6 +1,7 @@
 import { gql, useQuery } from "@apollo/client";
 import { Autocomplete, Icon } from "@bbtgnn/polaris-interfacer";
 import { SearchMinor } from "@shopify/polaris-icons";
+import { ProjectType } from "components/types";
 import { QUERY_PROJECT_TYPES } from "lib/QueryAndMutation";
 import { EconomicResource, GetProjectTypesQuery, SearchProjectsQuery, SearchProjectsQueryVariables } from "lib/types";
 import { useTranslation } from "next-i18next";
@@ -9,8 +10,6 @@ import * as yup from "yup";
 import ProjectThumb from "./ProjectThumb";
 
 //
-
-export type ProjectType = "design" | "service" | "product";
 
 export interface Props {
   onSelect?: (value: Partial<EconomicResource>) => void;

--- a/components/SearchUsers.tsx
+++ b/components/SearchUsers.tsx
@@ -1,6 +1,7 @@
 import { gql, useQuery } from "@apollo/client";
 import { Autocomplete, Icon } from "@bbtgnn/polaris-interfacer";
 import { SearchMinor } from "@shopify/polaris-icons";
+import { SelectOption } from "components/types";
 import { Agent, SearchAgentsQuery, SearchAgentsQueryVariables } from "lib/types";
 import { useTranslation } from "next-i18next";
 import { useCallback, useState } from "react";
@@ -84,12 +85,6 @@ export default function SearchUsers(props: Props) {
 }
 
 //
-
-export interface SelectOption {
-  value: string;
-  label: string;
-  media?: React.ReactElement;
-}
 
 export type FoundAgent = NonNullable<SearchAgentsQuery["agents"]>["edges"][number]["node"];
 

--- a/components/layout/CreateProjectLayout.tsx
+++ b/components/layout/CreateProjectLayout.tsx
@@ -1,11 +1,9 @@
 import { Link as PLink } from "@bbtgnn/polaris-interfacer";
-import { ProjectType } from "components/partials/create/project/CreateProjectForm";
 import { useTranslation } from "next-i18next";
 import Link from "next/link";
 
 type LayoutProps = {
   children: React.ReactNode;
-  projectType: ProjectType;
 };
 
 const CreateProjectLayout: React.FunctionComponent<LayoutProps> = (layoutProps: LayoutProps) => {

--- a/components/partials/create/project/CreateProjectForm.tsx
+++ b/components/partials/create/project/CreateProjectForm.tsx
@@ -1,3 +1,5 @@
+import { ProjectType } from "components/types";
+
 // Steps
 import {
   contributorsStepDefaultValues,
@@ -26,13 +28,12 @@ import CreateProjectFields from "./parts/CreateProjectFields";
 import CreateProjectNav from "./parts/CreateProjectNav";
 import CreateProjectSubmit from "./parts/CreateProjectSubmit";
 
+// Form
 import { yupResolver } from "@hookform/resolvers/yup";
 import { FormProvider, useForm } from "react-hook-form";
 import * as yup from "yup";
 
 //
-
-export type ProjectType = "service" | "product" | "design";
 
 export interface Props {
   projectType: ProjectType;
@@ -68,13 +69,13 @@ export const createProjectSchema = yup.object({
   location: yup
     .object()
     .when("$projectType", (projectType: ProjectType, schema) =>
-      projectType == "design" ? schema : locationStepSchema
+      projectType == ProjectType.DESIGN ? schema : locationStepSchema
     ),
   images: imagesStepSchema,
   declarations: yup
     .object()
     .when("$projectType", (projectType: ProjectType, schema) =>
-      projectType == "product" ? declarationsStepSchema : schema
+      projectType == ProjectType.PRODUCT ? declarationsStepSchema : schema
     ),
   contributors: contributorsStepSchema,
   relations: relationsStepSchema,

--- a/components/partials/create/project/parts/CreateProjectFields.tsx
+++ b/components/partials/create/project/parts/CreateProjectFields.tsx
@@ -1,7 +1,8 @@
+import { ProjectType } from "components/types";
 import { useTranslation } from "next-i18next";
 import React from "react";
 import { useFormContext } from "react-hook-form";
-import { CreateProjectValues, ProjectType } from "../CreateProjectForm";
+import { CreateProjectValues } from "../CreateProjectForm";
 
 // Steps
 import ContributorsStep from "../steps/ContributorsStep";
@@ -43,19 +44,19 @@ export const formSections: Array<FormSection> = [
     navLabel: "Import design",
     id: "importDesign",
     component: <ImportDesignStep />,
-    for: ["design"],
+    for: [ProjectType.DESIGN],
   },
   {
     navLabel: "General info",
     id: "main",
     component: <MainStep />,
-    required: ["product", "service", "design"],
+    required: [ProjectType.PRODUCT, ProjectType.SERVICE, ProjectType.DESIGN],
   },
   {
     navLabel: "Design source",
     id: "linkedDesign",
     component: <LinkDesignStep />,
-    for: ["product"],
+    for: [ProjectType.PRODUCT],
   },
   {
     navLabel: "Images",
@@ -65,28 +66,28 @@ export const formSections: Array<FormSection> = [
   {
     navLabel: "Location",
     id: "location",
-    component: <LocationStep projectType="product" />,
-    for: ["product"],
-    required: ["product"],
+    component: <LocationStep projectType={ProjectType.PRODUCT} />,
+    for: [ProjectType.PRODUCT],
+    required: [ProjectType.PRODUCT],
   },
   {
     navLabel: "Location",
     id: "location",
-    component: <LocationStep projectType="service" />,
-    for: ["service"],
+    component: <LocationStep projectType={ProjectType.SERVICE} />,
+    for: [ProjectType.SERVICE],
   },
   {
     navLabel: "Certifications",
     id: "declarations",
     component: <DeclarationsStep />,
-    for: ["product"],
-    required: ["product"],
+    for: [ProjectType.PRODUCT],
+    required: [ProjectType.PRODUCT],
   },
   {
     navLabel: "Licenses",
     id: "licenses",
     component: <LicenseStep />,
-    for: ["design"],
+    for: [ProjectType.DESIGN],
   },
   {
     navLabel: "Contributors",

--- a/components/partials/create/project/parts/CreateProjectNav.tsx
+++ b/components/partials/create/project/parts/CreateProjectNav.tsx
@@ -1,6 +1,6 @@
 import TableOfContents from "components/TableOfContents";
+import { ProjectType } from "components/types";
 import { useTranslation } from "next-i18next";
-import { ProjectType } from "../CreateProjectForm";
 import { getSectionByProjectType } from "./CreateProjectFields";
 
 export interface Props {

--- a/components/partials/create/project/steps/LinkDesignStep.tsx
+++ b/components/partials/create/project/steps/LinkDesignStep.tsx
@@ -3,6 +3,7 @@ import PCardWithAction from "components/polaris/PCardWithAction";
 import PTitleSubtitle from "components/polaris/PTitleSubtitle";
 import ProjectDisplay from "components/ProjectDisplay";
 import SearchProjects from "components/SearchProjects";
+import { ProjectType } from "components/types";
 import { EconomicResource } from "lib/types";
 import { useTranslation } from "next-i18next";
 import { useFormContext } from "react-hook-form";
@@ -36,7 +37,7 @@ export default function LinkDesign() {
     <Stack vertical spacing="extraLoose">
       <PTitleSubtitle title={t("Design source")} subtitle={t("Tell us from which design your product is based on.")} />
 
-      <SearchProjects label="Search for a design" conformsTo={["design"]} onSelect={handleSelect} />
+      <SearchProjects label="Search for a design" conformsTo={[ProjectType.DESIGN]} onSelect={handleSelect} />
 
       {selected && (
         <Stack vertical spacing="extraTight">

--- a/components/partials/create/project/steps/LocationStep.tsx
+++ b/components/partials/create/project/steps/LocationStep.tsx
@@ -1,12 +1,13 @@
 import { Checkbox, Stack, TextField } from "@bbtgnn/polaris-interfacer";
 import PTitleSubtitle from "components/polaris/PTitleSubtitle";
 import SelectLocation2 from "components/SelectLocation2";
+import { ProjectType } from "components/types";
 import { LocationLookup } from "lib/fetchLocation";
 import { isRequired } from "lib/isFieldRequired";
 import { useTranslation } from "next-i18next";
 import { Controller, useFormContext } from "react-hook-form";
 import * as yup from "yup";
-import { CreateProjectValues, ProjectType } from "../CreateProjectForm";
+import { CreateProjectValues } from "../CreateProjectForm";
 
 //
 
@@ -27,7 +28,7 @@ export const locationStepSchema = yup.object().shape({
   location: yup
     .object()
     .when("$projectType", (projectType: ProjectType, schema) =>
-      projectType === "product" ? schema.required() : schema.nullable()
+      projectType === ProjectType.PRODUCT ? schema.required() : schema.nullable()
     ),
   remote: yup.boolean(),
 });
@@ -39,7 +40,7 @@ export interface LocationStepSchemaContext {
 //
 
 export interface Props {
-  projectType?: Exclude<ProjectType, "design">;
+  projectType?: Exclude<ProjectType, ProjectType.DESIGN>;
 }
 
 //

--- a/components/types/index.ts
+++ b/components/types/index.ts
@@ -1,7 +1,19 @@
 import type React from "react";
 
+//
+
 export interface SelectOption {
   label: string;
   value: string;
   media?: React.ReactElement;
 }
+
+//
+
+export enum ProjectType {
+  DESIGN = "design",
+  PRODUCT = "product",
+  SERVICE = "service",
+}
+
+export const projectTypes = Object.values(ProjectType);

--- a/pages/create/project/design.tsx
+++ b/pages/create/project/design.tsx
@@ -1,3 +1,4 @@
+import { ProjectType } from "components/types";
 import { NextPageWithLayout } from "pages/_app";
 import { ReactElement } from "react";
 
@@ -9,7 +10,7 @@ import CreateProjectForm from "components/partials/create/project/CreateProjectF
 //
 
 const CreateDesign: NextPageWithLayout = () => {
-  return <CreateProjectForm projectType="design" />;
+  return <CreateProjectForm projectType={ProjectType.DESIGN} />;
 };
 
 //
@@ -17,7 +18,7 @@ const CreateDesign: NextPageWithLayout = () => {
 CreateDesign.getLayout = function getLayout(page: ReactElement) {
   return (
     <Layout>
-      <CreateProjectLayout projectType="design">{page}</CreateProjectLayout>
+      <CreateProjectLayout>{page}</CreateProjectLayout>
     </Layout>
   );
 };

--- a/pages/create/project/product.tsx
+++ b/pages/create/project/product.tsx
@@ -1,3 +1,4 @@
+import { ProjectType } from "components/types";
 import { NextPageWithLayout } from "pages/_app";
 import { ReactElement } from "react";
 
@@ -9,7 +10,7 @@ import CreateProjectForm from "components/partials/create/project/CreateProjectF
 //
 
 const CreateProduct: NextPageWithLayout = () => {
-  return <CreateProjectForm projectType="product" />;
+  return <CreateProjectForm projectType={ProjectType.PRODUCT} />;
 };
 
 //
@@ -17,7 +18,7 @@ const CreateProduct: NextPageWithLayout = () => {
 CreateProduct.getLayout = function getLayout(page: ReactElement) {
   return (
     <Layout>
-      <CreateProjectLayout projectType="product">{page}</CreateProjectLayout>
+      <CreateProjectLayout>{page}</CreateProjectLayout>
     </Layout>
   );
 };

--- a/pages/create/project/service.tsx
+++ b/pages/create/project/service.tsx
@@ -1,3 +1,4 @@
+import { ProjectType } from "components/types";
 import { NextPageWithLayout } from "pages/_app";
 import { ReactElement } from "react";
 
@@ -9,7 +10,7 @@ import CreateProjectForm from "components/partials/create/project/CreateProjectF
 //
 
 const CreateService: NextPageWithLayout = () => {
-  return <CreateProjectForm projectType="service" />;
+  return <CreateProjectForm projectType={ProjectType.SERVICE} />;
 };
 
 //
@@ -17,7 +18,7 @@ const CreateService: NextPageWithLayout = () => {
 CreateService.getLayout = function getLayout(page: ReactElement) {
   return (
     <Layout>
-      <CreateProjectLayout projectType="service">{page}</CreateProjectLayout>
+      <CreateProjectLayout>{page}</CreateProjectLayout>
     </Layout>
   );
 };


### PR DESCRIPTION
closes #391 

---

### Note

Not all `SelectOption` interfaces have been changed. Old components made with `react-select` (instead of Polaris Components) use a different version of `SelectOption` that has a `__isNew__` property.

Once all the components will be remade with Polaris, it will be possible to use everywhere the interface exported from `components/types/index.ts`