### PR TITLE
fix: 🐛 render tags decoded

### DIFF
--- a/components/brickroom/BrTags.tsx
+++ b/components/brickroom/BrTags.tsx
@@ -28,7 +28,7 @@ const BrTags = ({ tags }: { tags?: Array<string>; onCancel?: (tag: string) => vo
                   key={tag}
                   className={`bg-[#CDE4DF] text-[#5DA091] border-[#5DA091] border border-1 rounded-[4px] text-sm float-left mb-1 mr-1 px-0.5`}
                 >
-                  {tag}
+                  {decodeURI(tag)}
                 </a>
               </Link>
             ))}

--- a/hooks/useProjectCreation.ts
+++ b/hooks/useProjectCreation.ts
@@ -242,7 +242,7 @@ export const useProjectCreation = () => {
         devLog("error: images not prepared", e);
       }
 
-      const tags = formData.main.tags.map(t => encodeURI(t));
+      const tags = formData.main.tags;
       devLog("info: tags prepared", tags);
 
       const linkedDesign = formData.linkedDesign ? formData.linkedDesign : null;


### PR DESCRIPTION
should be fix tags rendered as URI strings