### PR TITLE
fix: 🐛 github actions fails after release of pnpm 8.0

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: latest
+          version: 7
           run_install: false
       - name: Get pnpm store directory
         id: pnpm-cache


### PR DESCRIPTION
quick fix of ci failure. the problem with pnpm is tracked in this issue: https://github.com/pnpm/pnpm/issues/6307