### PR TITLE
fix: 🐛  projects cards break the page after loadmore

### DIFF
--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -105,8 +105,8 @@ function StatsDisplay(props: { project: Partial<EconomicResource> }) {
   const { t } = useTranslation("common");
   const { project } = props;
 
-  const contributorsNum = project.metadata?.contributors.length;
-  const relationsNum = project.metadata?.relations.length;
+  const contributorsNum = project.metadata?.contributors?.length;
+  const relationsNum = project.metadata?.relations?.length;
 
   const stats = [
     { stat: contributorsNum, label: t("contributor", { count: contributorsNum }) },

--- a/components/ProjectsCards.tsx
+++ b/components/ProjectsCards.tsx
@@ -38,7 +38,6 @@ const ProjectsCards = (props: ProjectsCardsProps) => {
     filter = {},
     hideHeader = false,
     hidePagination = false,
-    hidePrimaryAccountable = false,
     hideFilters = false,
     tiny = false,
     header = "Latest projects",
@@ -46,7 +45,7 @@ const ProjectsCards = (props: ProjectsCardsProps) => {
   const dataQueryIdentifier = "economicResources";
 
   const { loading, data, fetchMore, refetch, variables } = useQuery<{ data: EconomicResource }>(FETCH_RESOURCES, {
-    variables: { last: 6, filter: filter },
+    variables: { last: 8, filter: filter },
   });
   const { loadMore, showEmptyState, items, getHasNextPage } = useLoadMore({
     fetchMore,


### PR DESCRIPTION
fix: #597 