### PR TITLE
fix: 🐛 removed file signing and updated types

### DIFF
--- a/hooks/useProjectCRUD.ts
+++ b/hooks/useProjectCRUD.ts
@@ -4,9 +4,6 @@ import { DeclarationsStepValues } from "components/partials/create/project/steps
 import { ProjectType } from "components/types";
 import useInBox from "hooks/useInBox";
 import useWallet from "hooks/useWallet";
-import { arrayEquals, getNewElements } from "lib/arrayOperations";
-import { errorFormatter } from "lib/errorFormatter";
-import { prepFilesForZenflows, uploadFiles } from "lib/fileUpload";
 import { IdeaPoints, StrengthsPoints } from "lib/PointsDistribution";
 import {
   ASK_RESOURCE_PRIMARY_ACCOUNTABLE,
@@ -20,6 +17,9 @@ import {
   RELOCATE_PROJECT,
   UPDATE_METADATA,
 } from "lib/QueryAndMutation";
+import { arrayEquals, getNewElements } from "lib/arrayOperations";
+import { errorFormatter } from "lib/errorFormatter";
+import { prepFilesForZenflows, uploadFiles } from "lib/fileUpload";
 import {
   CreateLocationMutation,
   CreateLocationMutationVariables,
@@ -33,8 +33,8 @@ import {
 import { useTranslation } from "next-i18next";
 import { AddedAsContributorNotification, MessageSubject, ProposalNotification } from "pages/notification";
 import { useState } from "react";
-import devLog from "../lib/devLog";
 import { QUERY_PROJECT_FOR_METADATA_UPDATE } from "../lib/QueryAndMutation";
+import devLog from "../lib/devLog";
 import {
   QueryProjectForMetadataUpdateQuery,
   QueryProjectForMetadataUpdateQueryVariables,
@@ -213,7 +213,7 @@ export const useProjectCRUD = () => {
       if (formData.location.locationData || formData.location.remote) {
         location = await handleCreateLocation(formData.location, projectType === ProjectType.DESIGN);
       }
-      const images: IFile[] = await prepFilesForZenflows(formData.images, getItem("eddsaPrivateKey"));
+      const images: IFile[] = await prepFilesForZenflows(formData.images);
       devLog("info: images prepared", images);
       const tags = formData.main.tags.length > 0 ? formData.main.tags : undefined;
       devLog("info: tags prepared", tags);

--- a/lib/fileUpload.ts
+++ b/lib/fileUpload.ts
@@ -64,7 +64,7 @@ export async function hashFile(ab: ArrayBuffer): Promise<string> {
 
 //
 
-export async function prepFileForZenflows(file: File, eddsa: string): Promise<IFile> {
+export async function prepFileForZenflows(file: File): Promise<IFile> {
   const hash = await createFileHash(file);
 
   return {
@@ -79,13 +79,13 @@ export async function prepFileForZenflows(file: File, eddsa: string): Promise<IF
 
 //
 
-export async function prepFilesForZenflows(images: Array<File>, eddsa: string): Promise<Array<IFile>> {
-  const prepImages: Array<IFile> = [];
-  for (let i of images) {
-    const image = await prepFileForZenflows(i, eddsa);
-    prepImages.push(image);
+export async function prepFilesForZenflows(files: Array<File>): Promise<Array<IFile>> {
+  const preppedFiles: Array<IFile> = [];
+  for (let f of files) {
+    const file = await prepFileForZenflows(f);
+    preppedFiles.push(file);
   }
-  return prepImages;
+  return preppedFiles;
 }
 
 //

--- a/lib/fileUpload.ts
+++ b/lib/fileUpload.ts
@@ -14,11 +14,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { IFile } from "lib/types";
-import signFile from "zenflows-crypto/src/sign_file";
-import { zencode_exec, zenroom_hash_final, zenroom_hash_init, zenroom_hash_update } from "zenroom";
-import devLog from "./devLog";
 import base64url from "base64url";
+import { IFile } from "lib/types";
+import { zenroom_hash_final, zenroom_hash_init, zenroom_hash_update } from "zenroom";
+import devLog from "./devLog";
 
 //
 
@@ -65,19 +64,8 @@ export async function hashFile(ab: ArrayBuffer): Promise<string> {
 
 //
 
-export async function createFileSignature(hash: string, eddsa: string): Promise<string> {
-  const { result } = await zencode_exec(signFile(), {
-    data: createZenData(hash),
-    keys: createZenKeys(eddsa),
-  });
-  return await JSON.parse(result).eddsa_signature;
-}
-
-//
-
 export async function prepFileForZenflows(file: File, eddsa: string): Promise<IFile> {
   const hash = await createFileHash(file);
-  const signature = await createFileSignature(hash, eddsa);
 
   return {
     name: file.name,
@@ -86,7 +74,6 @@ export async function prepFileForZenflows(file: File, eddsa: string): Promise<IF
     hash,
     mimeType: file.type,
     size: file.size,
-    signature,
   };
 }
 

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -700,7 +700,7 @@ export type IFile = {
   height?: InputMaybe<Scalars["Int"]>;
   mimeType: Scalars["String"];
   name: Scalars["String"];
-  signature: Scalars["String"];
+  signature?: Scalars["String"];
   size: Scalars["Int"];
   width?: InputMaybe<Scalars["Int"]>;
 };


### PR DESCRIPTION
At the time of opening this PR, the backend testing instance does not implement the file signature changes.
This means that when types are generated from gql, `signature` field is still required.

This PR will be merged once the backend testing instance gets updated, and types can be properly generated (instead of manually fixing the file).