### PR TITLE
chore: 🔧 open did in a separate tab

### DIFF
--- a/components/partials/profile/[id]/ProfileHeading.tsx
+++ b/components/partials/profile/[id]/ProfileHeading.tsx
@@ -63,7 +63,7 @@ const ProfileHeading = () => {
       <Heading label={"DID:"}>
         <Text as="span" variant="bodyLg">
           <Link url={didUrl}>
-            <a>
+            <a target="_blank">
               <Button primary>{t("DID Explorer")}</Button>
             </a>
           </Link>


### PR DESCRIPTION
fixes #433
