### PR TITLE
Revert "fix: 🐛 should be not mention the product in the parent design (#749)"

### DIFF
--- a/hooks/useProjectCRUD.ts
+++ b/hooks/useProjectCRUD.ts
@@ -263,13 +263,13 @@ export const useProjectCRUD = () => {
           process: processId,
           originalProjectId: projectId,
         });
-        // const project = await getProjectForMetadataUpdate(linkedDesign);
-        // if (project.metadata?.relations) {
-        //   const relations: string[] = [...project.metadata.relations, projectId];
-        //   await updateRelations(linkedDesign, relations, true);
-        // } else {
-        //   await updateRelations(linkedDesign, [projectId], true);
-        // }
+        const project = await getProjectForMetadataUpdate(linkedDesign);
+        if (project.metadata?.relations) {
+          const relations: string[] = [...project.metadata.relations, projectId];
+          await updateRelations(linkedDesign, relations, true);
+        } else {
+          await updateRelations(linkedDesign, [projectId], true);
+        }
       }
 
       for (const resource of formData.relations) {


### PR DESCRIPTION
This reverts commit 31513cd2bd3f28cda3e4e22ce5e6ecda72eac0b9.
