### PR TITLE
fix back button

### DIFF
--- a/components/partials/create/contribution/CreateContributionForm.tsx
+++ b/components/partials/create/contribution/CreateContributionForm.tsx
@@ -36,9 +36,9 @@ import PLabel from "components/polaris/PLabel";
 import PTitleSubtitle from "components/polaris/PTitleSubtitle";
 import useYupLocaleObject from "hooks/useYupLocaleObject";
 import { isRequired } from "lib/isFieldRequired";
-import { useRouter } from "next/router";
 import React, { ReactNode } from "react";
 import SelectProjectForContribution from "../project/steps/SelectProjectForContribution";
+import Link from "next/dist/client/link";
 
 //
 
@@ -221,21 +221,16 @@ const CreateContributionForm = (props: Props) => {
   //
 
   const Layout = ({ children }: { children: ReactNode }) => {
-    const router = useRouter();
     const { t } = useTranslation("common");
     return (
       <FormProvider {...form}>
         <form onSubmit={handleSubmit(onSubmit)}>
           <div className="p-4 text-text-primary">
-            <Button
-              onClick={() => {
-                router.back();
-              }}
-              plain
-              monochrome
+            <Link
+              href={`/project/${resource?.id}`}
             >
               {t("← Discard and go back")}
-            </Button>
+            </Link>
           </div>
           <div className="flex justify-center items-start space-x-8 md:space-x-16 lg:space-x-24 p-6">
             <div className="sticky top-24">

--- a/components/partials/project/[id]/sidebar/TechnicalInfoCard.tsx
+++ b/components/partials/project/[id]/sidebar/TechnicalInfoCard.tsx
@@ -16,7 +16,7 @@ const TechnicalInfoCard = () => {
   const haveDeclarations = declarations?.recyclable === "yes" || declarations?.repairable === "yes";
   const licenses = project.metadata?.licenses?.length && project?.metadata?.licenses;
   const design = project.metadata?.design;
-  const certifications: Array<ILink> | undefined = project.metadata.declarations?.certifications;
+  const certifications: Array<ILink> | undefined = project.metadata?.declarations?.certifications;
 
   if (!(licenses || design || haveDeclarations || certifications?.length)) return null;
 


### PR DESCRIPTION
- **fix: 🐛 add more public keys at agent creation (#381)**
- **refactor: ♻️ new create resource mutation (#398)**
- **reuse: update (#389)**
- **fix: 🐛 image was missing at login**
- **feat(createProject): ✨ Form Refactoring and Differentiation (#355)**
- **feat(Components): ✨ created new Tags comp (#419)**
- **fix: 🐛  design creation page (#418)**
- **feat: Project creation – Main step – Implemented new tags component (#421)**
- **fix: 🐛 added ts-ignore to module**
- **fix: 🐛 project detail visible for not logged users (#417)**
- **fix: 🐛 prepare image Ifile in project creation (#426)**
- **Fix: notification (#427)**
- **fix: 🐛 design contribution was broken (#428)**
- **fix: 🐛 remove burger menu from nru layout (#429)**
- **fix: 🐛 render tags decoded (#430)**
- **Fix: contributors table and relations table (#432)**
- **feat: ✨ assign w3c distributed identity to agents (#406)**
- **fix(ImportDesignStep): 🐛 removed required indicator**
- **fix: 🐛 did explorer on a new tab**
- **fix(CreateProject): 🐛 fixed validation trigger (#442)**
- **refactor: ♻️ Add new image in NRU layout (#443)**
- **chore: 🔧 removed unused files**
- **fix: 🐛 allow project creation on autoimport without tag (#450)**
- **feat(MainStep): ✨ added validation on description length (#451)**
- **fix(ImportDesignStep): 🐛 changed url validation (#452)**
- **feat(ProjectPage): ✨ added redirect if losh project (#453)**
- **fix: 🐛 at project creation tags should be not mandatory (#448)**
- **feat(CreateProjectForm): ✨ added autofocus on field (#454)**
- **refactor: ♻️ Replaced project creation icons (#457)**
- **refactor: ♻️ put count interval for inbox in the .env (#458)**
- **fix: 🐛 agents cant claim losh resources twice (#456)**
- **feat: ✨ Add .env to gitignore for unwanted commits ;p (#459)**
- **fix: 🐛 queries to economic resources become slower (#466)**
- **fix: 🐛 contributors table agents missing (#465)**
- **feat: User search by username (#467)**
- **fix(forms): 🐛 changed setValue options**
- **feat(Project): ✨ added `/edit` mode (#414)**
- **fix: 🐛 small style fixes**
- **feat(FetchProjectLayout): ✨ edited gql query**
- **fix: 🐛 made ProjectType values title case**
- **feat: ✨ added mutation for update metadata (#475)**
- **feat(EditProject): ✨ added contributors page (#471)**
- **feat: Edit project – Licenses page (#472)**
- **feat(EditProject): ✨ added relations page (#473)**
- **feat(EditProject): ✨ added declarations edit (#478)**
- **feat: ✨ update project location function (#485)**
- **test: 🚨  refactor cypress screenshots tools (#476)**
- **feat: ✨ remote location flag in the metadata of a project (#487)**
- **feat: Edit project – Updated routing (#490)**
- **feat: ✨ Readable READMEs (#483)**
- **fix(TableOfContentsLink): 🐛 updated link style**
- **fix: 🐛 on 0 status trend resume should be green (#445)**
- **feat: ♻️ 404 page (#491)**
- **feat: Edit project – Location page (#496)**
- **fix: 🐛 visible spinner before edit page (#499)**
- **footer (#498)**
- **fix: 🐛 Fix missing license import from GH (#502)**
- **feat: cards hp (#503)**
- **refactor: ♻️ new assets and copy for the hero index (#501)**
- **fix: 🐛 Add dependency types for icons**
- **feat: ✨ added edit button link (#507)**
- **fix: filters component (#508)**
- **fix: 🐛 Allow self contributions (#510)**
- **feat(ProjectPage): ✨ changed DPP tab (#511)**
- **fix: 🐛 on accept contribution consistent relations inside metadata (#513)**
- **fix: 🐛 removed duplicate**
- **fix: 🐛 small padding fix**
- **fix: 🐛 removed unnecessary bg color**
- **fix(footer): 🐛 changed spacing and sizes**
- **refactor: ♻️ Refactor the edit page as needed by the designers (#506)**
- **chore: 🔧 fixes #504**
- **feat(notifications): ✨ added unread display (#514)**
- **feat: cite projects update also cited projects (#516)**
- **fix: 🐛 i18n-ally changed settings**
- **feat(CreateProject): translations setup, translated MainStep (#518)**
- **feat: ✨ Implement more coherent design on profile page (#520)**
- **fix: 🐛 set count unread intervall from .env (#517)**
- **feat: ✨ osh tool component (#519)**
- **chore: 🔧 copy and images (#521)**
- **feat: Better callout (#522)**
- **test: 🚨 fix hompage nru copy**
- **feat: ✨ Add new copy and links to the footer (#523)**
- **feat: Create Project – Added translations (#524)**
- **fix: small UI fixes (#525)**
- **fix: remove #e46; (#527)**
- **refactor(ProjectPage): ♻️ created sidebar component for easy move (#528)**
- **Fix German sidebar (#531)**
- **Fix french sidebar (#533)**
- **Fix italian sidebar (#534)**
- **chore: 🔧 fix notification z-index (#532)**
- **fix: 🐛 the search for user (#535)**
- **feat: cards on projects page (#536)**
- **docs: :memo: update link**
- **fix: 🐛 update /projects page component tests (#537)**
- **fix: 🐛 no license, no declarations and no design the block should disappear (#538)**
- **feat: ✨ Initial bare implementation of the map (#512)**
- **feat: ✨ on autoimport github readme files fix relatives urls (#556)**
- **Fix signup email error (#554)**
- **refactor: refactoring map and style (#542)**
- **fix: 🐛 show points and trends for cycle (#552)**
- **feat: Profile dropdown in navbar (#568)**
- **fix: 🐛 projects last update showed wrong data (#572)**
- **Refactor: project detail (#577)**
- **test: 🚨 update logout test (#582)**
- **feat: added Notifications dropdown (#574)**
- **feat(EditProject): ✨ added navigation guard if changes (#578)**
- **fix: 🐛 translations**
- **feat: at least one image at project creation (#585)**
- **fix: 🐛 github actions fails after release of pnpm 8.0 (#588)**
- **feat: Project card fixes (#586)**
- **fix: 🐛 pnpm update causes trouble also during cypress action (#590)**
- **feat: ✨ add iubenda privacy policy (#573)**
- **feat: ✨ qr code for projects (#587)**
- **fix: 🐛 error proof and loosy data render on missing attrs (#593)**
- **fix: 🐛 missing metadata should not broke pages (#594)**
- **fix: 🐛  projects cards break the page after loadmore (#598)**
- **fix: 🐛 Add focus on the first fields of forms (#616)**
- **feat: ✨ remove invitation key for registration (#621)**
- **feat: Added verify email page (#626)**
- **fix(SignUp): 🐛 reintroduced invitation key**
- **fix: 🐛 claimed projects cards dont have image (#640)**
- **feat(AuthContext): Updated user data load (#630)**
- **chore: 🔧 nicer number of paged projects and search after card refactoring (#591)**
- **fix: 🐛 Max width prevent to broke on super large images (#613)**
- **build: 📦️ configure webpack to embed .zen files (#600)**
- **fix: 🐛 brUserAvatar use wrong user variable (#651)**
- **fix: 🐛 non existing project should redirect to 404 (#650)**
- **fix: 🐛 change about this platform link (#649)**
- **fix: 🐛 my projects in profile detail should show only my projects (#648)**
- **fix: 🐛 Prevent empty error on user creation (not auth before email check) (#653)**
- **feat(Profile): ✨ added email verified badge (#656)**
- **fix: 🐛 some project do not have declarations but project detail should still work (#665)**
- **feat(SignUp): ✨ added user and email verification (#659)**
- **feat: ✨ add share button for projects (#661)**
- **feat(Home): ✨ updated "features" section (#666)**
- **fix( Project Type Chip): opens in new tab (#667)**
- **feat(Project): ✨ added certifications to sidebar (#669)**
- **fix(Home): 🐛 removed autofocus on map (#670)**
- **feat( Profile ): Added empty states for projects (#675)**
- **feat(HomeMap): ✨ removed scroll zoom, added controls (#671)**
- **fix: project with missing certifications are broken (#678)**
- **fix(AuthContext): 🐛 changed mutation handling (#664)**
- **feat: ✨save draft projects (#589)**
- **fix: 🐛 Remove ENV from Dockerfile (#689)**
- **fix(ShareButton): 🐛 updated style (#692)**
- **refactor: Rework claim (#641)**
- **I18n: transalate forms error (#642)**
- **refactor: remove user location in project sidebar if project location (#643)**
- **chore: 🔧 take care of build warnings (#645)**
- **feat(SearchTags): ✨ Can't create tag if already selected (#693)**
- **fix(TopbarUser): 🐛 Changed overflow rules (#695)**
- **feat: ✨ in project creation use user location as default value (#697)**
- **fix: 🐛 remove @ before username (#698)**
- **fix: 🐛 in serch result page not display correctcly length (#699)**
- **test: migrate to Playwright (#696)**
- **fix: move build to startup (runtime) (#708)**
- **test: 🚨 fix tests (#707)**
- **fix: 🐛  type check error during --prod build (#709)**
- **fix(AuthContext): 🐛 updated Email Verification (#711)**
- **chore: 🔧 open did in a separate tab (#702)**
- **fix: 🐛 max-width of profile bio (#710)**
- **feat: open graph for social sharing (#701)**
- **fix: 🐛 in notification was showed the wrong user as proposer (#714)**
- **chore: Update publish.yml (#704)**
- **feat(EmailVerification): ✨ added beta.interfacer.dyne url (#718)**
- **feat ( Edit Project ): Edit images (#660)**
- **copy📝: Change related project to included project and some copy  embroideries (#717)**
- **chore: replace google fonts with @fountsource (#719)**
- **refactor: rework contribution (#706)**
- **fix: 🐛 osh tool was broken (#722)**
- **refactor: project card and cards for losh and projects (#713)**
- **feat✨: better search experience (#720)**
- **fix: 🐛 open to not registered user imported from losh resources (#724)**
- **fix: 🐛 map: show more project in a popup, anchor left, faster zoom (#725)**
- **fix: 🐛 projects cards in relations tab (#729)**
- **test: 🚨 add tests for page as not registered users (#730)**
- **fix: 🐛 in search page map, losh should be not shown (#731)**
- **copy: review (#732)**
- **fix: 🐛 no child in father (#733)**
- **test: 🚨 fix profile page test (#734)**
- **feat: ✨ remove the invitation key for production (#726)**
- **test: 🚨 don't test invitation key (#739)**
- **fix: 🐛  cards should never show broken images (#738)**
- **fix: 🐛 project sidebar shrink too much on long title projects (#735)**
- **fix: show when a resource was added to if (#736)**
- **fix: 🐛 if you are on /Notifications and press on Home, nothing happens (#740)**
- **ci: 👷 enable logs (#743)**
- **test: 🚨 fix nru test for signup after invitation key remove (#741)**
- **fix: 🐛 useWallet was out of order (#744)**
- **fix: 🐛 user display in sidebar (#745)**
- **fix: 🐛 show empty state in search for users (#742)**
- **style: 🎨 take care of some translations (#737)**
- **fix: 🐛 propose contribution description editor (#747)**
- **fix: 🐛 should be not mention the product in the parent design (#749)**
- **Revert "fix: 🐛 should be not mention the product in the parent design (#749)" (#752)**
- **fix: 🐛 DPP in production**
- **fix: 🐛 dont mention product in the parent design (#753)**
- **fix: 🐛 is better to use css for text ellipsis (#759)**
- **fix: 🐛 /notification page did not show notifications (#757)**
- **Update Live demo link in README.md (#773)**
- **fix: 🐛 if project title is one long word break it in mobile (#778)**
- **build(deps): bump actions/download-artifact from 2 to 4.1.7 in /.github/workflows (#787)**
- **fix: email template for new environment (#789)**
- **fix: missing projects in home (#786)**
- **chore🧹: Lazy loading components (#764)**
- **chore: 🔧 treeshake useless field in licenses (#762)**
- **fix: contribute to aproject back button**
